### PR TITLE
Add MIT as license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,1 +1,19 @@
-Copyright (C) 2020 Fluves - All Rights Reserved
+Copyright (C) 2020-2024 Fluves
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Geopandas, Rasterio, Pandas and Numpy). To install the package:
 .. note::
 
     Note that it relies on dependencies you need to install yourselves, see
-    :ref:`installation instructions <installation>` for more information.
+     `installation instructions <https://watem-sedem.github.io/pywatemsedem/installation.html>`_ for more information.
 
 Documentation
 -------------
@@ -42,8 +42,8 @@ The open-source code can be found on
 
 License
 -------
-This project is licensed under **TODO**, see
-:ref:`here <license>` for more information.
+This project is licensed under MIT, see
+`license <https://watem-sedem.github.io/pywatemsedem/license.html>`_ for more information.
 
 Projects
 --------

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ name = pywatemsedem
 description = Python Wrapper for WaTEM/SEDEM
 author = Sacha Gobeyn
 author_email = sacha@fluves.com
-license = Proprietary
+license = MIT
 long_description = file: README.rst
 long_description_content_type = text/x-rst; charset=UTF-8
 #url = https://
@@ -21,6 +21,9 @@ classifiers =
     Development Status :: 4 - Beta
     Programming Language :: Python
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Intended Audience :: Science/Research
     Natural Language :: English
     Topic :: Scientific/Engineering


### PR DESCRIPTION
Note that I chose MIT over LGPL as a license because it allows broader usage. This license is compatible with the other watem-sedem projects, but by making it MIT instead of LGPL it is easier to reuse code in Python projects that generally use MIT (eg pydov, niche vlaanderen, pywaterinfo).