### PR TITLE
enable explicit reference to epsg-code (as required in Catchment)

### DIFF
--- a/src/pywatemsedem/catchment.py
+++ b/src/pywatemsedem/catchment.py
@@ -183,7 +183,7 @@ class Catchment(Factory):
 
         # get RasterProperties from catchment vector and bounds DTM
         rp = read_rasterio_profile(rst_dtm)
-        bounds = RasterProperties.from_rasterio(rp).bounds
+        bounds = RasterProperties.from_rasterio(rp, epsg=epsg_code).bounds
         self.rp = define_extent_from_vct(
             self.vct_catchment,
             resolution,


### PR DESCRIPTION
See https://github.com/watem-sedem/pywatemsedem/issues/22: the code breaks when you input a DTM without any defined coordinate system. This is fixed with the commit, explicit inputting of EPSG is required (and input raster are check to this epsg_code). @SethCallewaert : this fixes https://github.com/watem-sedem/pywatemsedem/issues/22