### PR TITLE
add custom code to check if SAGA/WaTEM is properly installed

### DIFF
--- a/src/pywatemsedem/__init__.py
+++ b/src/pywatemsedem/__init__.py
@@ -16,3 +16,16 @@ except PackageNotFoundError:  # pragma: no cover
     __version__ = "unknown"
 finally:
     del version, PackageNotFoundError
+
+# check if SAGA/WaTEM topology is installed properly
+import subprocess
+
+try:
+    subprocess.check_output(["saga_cmd", "topology"], stderr=subprocess.STDOUT)
+except subprocess.CalledProcessError as e:
+    if "Error: select a library" in e.output.decode():
+        msg = (
+            "SAGA/WaTEM is not properly installed, check the installation instruction "
+            "in the documentation."
+        )
+        raise OSError(msg)


### PR DESCRIPTION
It seems SAGA/WaTEM is often forgotten in the installation. Upon import of the package, it is checked if the tools of SAGA/WaTEM are present. 

@johanvdw :

-  please suggest a more elegant solution if you have one. See also https://github.com/watem-sedem/pywatemsedem/issues/21. Please leave it in import-stage somewhere as we want early message that something is wrong.
- I was not able to implement an error when SAGA is missing from system, do you have a suggestions for that?