### PR TITLE
Adjust temp files

### DIFF
--- a/src/pywatemsedem/catchment.py
+++ b/src/pywatemsedem/catchment.py
@@ -16,6 +16,7 @@ from pywatemsedem.geo.rasterproperties import RasterProperties
 from pywatemsedem.geo.rasters import AbstractRaster, RasterMemory
 from pywatemsedem.geo.utils import (
     any_equal_element_in_vector,
+    clean_up_tempfiles,
     create_filename,
     create_spatial_index,
     define_extent_from_vct,
@@ -265,9 +266,9 @@ class Catchment(Factory):
             msg = "failed to filter_within_parcels dtm"
             execute_subprocess(cmd_args, msg)
             self._dtm._arr, _ = load_raster(temp_dtm.with_suffix(".sdat"))
-            # clean_up_tempfiles(temp_landuse, "tiff")
-            # clean_up_tempfiles(temp_dtm, "saga")
-            # clean_up_tempfiles(temp_dtm_in, "rst")
+            clean_up_tempfiles(temp_landuse, "tiff")
+            clean_up_tempfiles(temp_dtm, "saga")
+            clean_up_tempfiles(temp_dtm_in, "rst")
 
         self._dtm.filter = filter_within_parcels
 
@@ -650,7 +651,7 @@ class Catchment(Factory):
         # clip
         vct_river_clipped = self.folder.vct_folder / f"river_{self.name}.shp"
         # remove temporary files
-        # clean_up_tempfiles(vct_river_clipped, "shp")
+        clean_up_tempfiles(vct_river_clipped, "shp")
         self._vct_river = self.vector_factory(
             vector_input, "LineString", allow_empty=True
         )
@@ -659,7 +660,7 @@ class Catchment(Factory):
         # set topologize
         logger.info("Preparing river topology...")
         vct_river_topo = self.folder.vct_folder / f"topology_{self.name}.shp"
-        # clean_up_tempfiles(vct_river_topo, "shp")
+        clean_up_tempfiles(vct_river_topo, "shp")
         self._adjacent_edges, self._up_edges = self.topologize_river(
             vct_river_clipped, vct_river_topo, self.mask_raster
         )
@@ -865,8 +866,8 @@ class Catchment(Factory):
         adjacent_edges = pd.read_csv(str(temp_adjacent_edges), sep="\t")
         up_edges = pd.read_csv(str(temp_up_edges), sep="\t")
 
-        # clean_up_tempfiles(temp_up_edges, "txt")
-        # clean_up_tempfiles(temp_adjacent_edges, "txt")
+        clean_up_tempfiles(temp_up_edges, "txt")
+        clean_up_tempfiles(temp_adjacent_edges, "txt")
 
         return adjacent_edges, up_edges
 

--- a/src/pywatemsedem/cfactor.py
+++ b/src/pywatemsedem/cfactor.py
@@ -7,7 +7,7 @@ from pywatemsedem.grasstrips import (
     scale_cfactor_with_grass_strips_width,
 )
 
-from .geo.utils import create_filename
+from .geo.utils import clean_up_tempfiles, create_filename
 
 
 def create_cfactor_degerick2015(
@@ -161,7 +161,7 @@ def create_cfactor_degerick2015(
     arr_mask = np.where(mask.arr, cfactor_aggriculture, 0)
     arr_cfactor = np.where(arr_cfactor == nodata, arr_mask, arr_cfactor)
     arr_cfactor = arr_cfactor.astype("float32")
-    # clean_up_tempfiles(tiff_temp, "tiff")
+    clean_up_tempfiles(tiff_temp, "tiff")
 
     return vct_grass_strips, arr_cfactor
 

--- a/src/pywatemsedem/geo/factory.py
+++ b/src/pywatemsedem/geo/factory.py
@@ -12,6 +12,7 @@ from rasterio import RasterioIOError
 from .rasterproperties import RasterProperties
 from .rasters import RasterFile, RasterMemory, TemporalRaster
 from .utils import (
+    clean_up_tempfiles,
     create_filename,
     define_extent_from_vct,
     generate_vct_mask_from_raster_mask,
@@ -158,7 +159,7 @@ class Factory:
                 tf_rst = create_filename(".tif")
                 vct_to_rst_value(mask, tf_rst, 1, self.rp.gdal_profile)
                 arr, _ = load_raster(tf_rst)
-                # clean_up_tempfiles(tf_rst, "tiff")
+                clean_up_tempfiles(tf_rst, "tiff")
                 self._vct_mask = VectorFile(mask)
         else:
             arr, rp = load_raster(mask)

--- a/src/pywatemsedem/geo/rasters.py
+++ b/src/pywatemsedem/geo/rasters.py
@@ -175,7 +175,7 @@ class AbstractRaster:
             tiff_temp = create_filename(".tif")
             write_arr_as_rst(self._arr, tiff_temp, dtype, profile)
             tiff_to_idrisi(tiff_temp, outfile_path, dtype=dtype)
-            # clean_up_tempfiles(tiff_temp, "tiff")
+            clean_up_tempfiles(tiff_temp, "tiff")
 
         return True
 
@@ -367,7 +367,7 @@ class RasterFile(AbstractRaster):
         )
         arr, profile = load_raster(rst_temp)
         shape = arr[arr != profile["nodata"]].shape
-        # clean_up_tempfiles(rst_temp, "rst")
+        clean_up_tempfiles(rst_temp, "rst")
 
         if shape == (0,):
             msg = (

--- a/src/pywatemsedem/geo/utils.py
+++ b/src/pywatemsedem/geo/utils.py
@@ -2102,7 +2102,11 @@ def define_extent_from_vct(
 
 
 def create_filename(suffix, directory=Path("tempfiles_pywatemsedem")):
-    """Create temporary files in a dedicated directory
+    """Create temporary filename in a dedicated directory
+
+    Create directory if it is not exists
+
+    Only filenames are generated, not the files
 
     Parameters
     ----------
@@ -2113,8 +2117,7 @@ def create_filename(suffix, directory=Path("tempfiles_pywatemsedem")):
     -------
     pathlib.Path
     """
-    if not directory.exists():
-        directory.mkdir()
+    directory.mkdir(exists_ok=True)
     timestamp = int(time.time())
     chars = string.ascii_letters + string.digits
     random_part = "".join(random.choices(chars, k=6))

--- a/src/pywatemsedem/geo/vectors.py
+++ b/src/pywatemsedem/geo/vectors.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from .rasterproperties import RasterProperties
 from .utils import (
+    clean_up_tempfiles,
     clip_vct,
     create_filename,
     create_spatial_index,
@@ -202,7 +203,7 @@ class AbstractVector:
             tf_rst = create_filename(".tif")
             vct_to_rst_field(vct_temp, tf_rst, rp.gdal_profile, col)
             arr, _ = load_raster(tf_rst)
-            # clean_up_tempfiles(tf_rst, "tiff")
+            clean_up_tempfiles(tf_rst, "tiff")
 
         else:
             tf_rst = create_filename(".sgrid")
@@ -224,10 +225,10 @@ class AbstractVector:
             # correct no data value if necessary
             if profile["nodata"] != rp.nodata:
                 arr[arr == profile["nodata"]] = rp.nodata
-            # clean_up_tempfiles(tf_rst, "tiff")
-            # clean_up_tempfiles(tf_rst, "saga")
+            clean_up_tempfiles(tf_rst, "tiff")
+            clean_up_tempfiles(tf_rst, "saga")
 
-        # clean_up_tempfiles(vct_temp, "shp")
+        clean_up_tempfiles(vct_temp, "shp")
 
         return arr
 
@@ -323,6 +324,6 @@ class VectorFile(AbstractVector):
         vct_temp = create_filename(".shp")
         clip_vct(file_path, vct_temp, vct_clip)
         geodata = gpd.read_file(vct_temp)
-        # clean_up_tempfiles(vct_temp, "shp")
+        clean_up_tempfiles(vct_temp, "shp")
 
         return geodata

--- a/src/pywatemsedem/grasstrips.py
+++ b/src/pywatemsedem/grasstrips.py
@@ -870,8 +870,8 @@ def create_grass_strips_from_line_string(
         grass_strips = grass_strips.dissolve("NR")
         grass_strips["width"] = width
         grass_strips["scale_ktc"] = 1
-        # clean_up_tempfiles(tmp_bankgrasstrips, "shp")
-        # clean_up_tempfiles(tmp_polygons, "shp")
-        # clean_up_tempfiles(tmp_bankstrips_polygons, "shp")
+        clean_up_tempfiles(tmp_bankgrasstrips, "shp")
+        clean_up_tempfiles(tmp_polygons, "shp")
+        clean_up_tempfiles(tmp_bankstrips_polygons, "shp")
 
     return grass_strips.reset_index()[["width", "scale_ktc", "geometry"]]

--- a/src/pywatemsedem/io/modeloutput.py
+++ b/src/pywatemsedem/io/modeloutput.py
@@ -16,6 +16,7 @@ from pywatemsedem.plots import plot_cumulative_sedimentload
 from ..geo.factory import Factory
 from ..geo.utils import (
     check_raster_properties_raster_with_template,
+    clean_up_tempfiles,
     create_filename,
     create_spatial_index,
     execute_saga,
@@ -1609,7 +1610,7 @@ def map_rank_sediment_loads(
     gdf_out = gdf_out.merge(df_sediexport, on="rank")
     if unit == "ton":
         gdf_out["sediexport"] = gdf_out["sediexport"] / 1000
-    # clean_up_tempfiles(Path(rst_out), "rst")
+    clean_up_tempfiles(Path(rst_out), "rst")
 
     return gdf_out
 

--- a/src/pywatemsedem/ktc.py
+++ b/src/pywatemsedem/ktc.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from pywatemsedem.grasstrips import scale_ktc_with_grass_strip_width, scale_ktc_zhang
 
-from .geo.utils import create_filename
+from .geo.utils import clean_up_tempfiles, create_filename
 
 
 def create_ktc(
@@ -88,7 +88,7 @@ def create_ktc(
     else:
         arr_ktc = np.where(composite_landuse.arr == -6, ktc_low, arr_ktc)
 
-    # clean_up_tempfiles(tiff_temp, "tiff")
+    clean_up_tempfiles(tiff_temp, "tiff")
 
     return arr_ktc, grass
 

--- a/src/pywatemsedem/postprocess.py
+++ b/src/pywatemsedem/postprocess.py
@@ -11,6 +11,7 @@ import shapely
 from pywatemsedem.defaults import SAGA_FLAGS
 from pywatemsedem.geo.factory import Factory
 from pywatemsedem.geo.utils import (
+    clean_up_tempfiles,
     compute_statistics_rasters_per_polygon_vector,
     create_filename,
     create_spatial_index,
@@ -562,7 +563,7 @@ class PostProcess(Factory):
             resmap=self.sfolder.postprocess_folder,
             epsg=self.epsg,
         )
-        # clean_up_tempfiles(temp_routing_wide, "txt")
+        clean_up_tempfiles(temp_routing_wide, "txt")
 
     def merge_overlapping_catchments(self, gdf_subcatchmpriority, merge=True):
         """Merge overlapping catchments and reassign priorities for
@@ -716,7 +717,7 @@ class PostProcess(Factory):
         )
         # check lijn hieronder
         df_subcatchments.to_file(dict_vct_subcatchmsinks[percentage])
-        # clean_up_tempfiles(temp, "txt")
+        clean_up_tempfiles(temp, "txt")
 
     def identify_sinks(self, percentage):
         """Identify X % highest sinks of sediment.


### PR DESCRIPTION
Temporary file handling was not uniform over the code. It poses the risk that unwanted side effects appear. It might explain the random exit observed in NEMO.

- A seperate folder in the main directory of the run is now generated.
- File name generation is now uniform.
- File removal is (temporarily) disabled.

- [x] A functionality to remove files after WaTEM/SEDEM run will be added.

@baris-o : you can test if this branch works for NEMO.