### PR TITLE
add open water data value to the docstrings

### DIFF
--- a/src/pywatemsedem/scenario.py
+++ b/src/pywatemsedem/scenario.py
@@ -375,6 +375,7 @@ class Scenario:
         The parcels vector should be polygon vector. Should contain a definition of
         land-use (column "LANDUSE"):
 
+            - *-5*: open water
             - *-4*: grass land
             - *-3*: forest
             - *-2*: infrastructure (farms)
@@ -399,8 +400,8 @@ class Scenario:
         vector_input: Pathlib.Path, str or geopandas.GeoDataFrame
             Polygon vector
 
-            - *LANDUSE* (int): landuse value (-4: grass land, -3: forest,
-               -2: infrastructure (farms), -9999: agricultural land).
+            - *LANDUSE* (int): landuse value (-5: open water, -4: grass land, -3:
+            forest, -2: infrastructure (farms), -9999: agricultural land).
             - *C_crop* (float): C-factor for crop, valid for considered time period
               ([0,1], NULL-values allowed).
             - *NR* (int, optional): id.
@@ -511,6 +512,7 @@ class Scenario:
         pywatemsedem.geo.rasters.AbstractRaster, else None
             Float64 raster with values:
 
+            - *-5*: open water
             - *-4*: grass land
             - *-3*: forest
             - *-2*: infrastructure (farms)


### PR DESCRIPTION
# What
This PR handles resolves the incomplete list of possible land use values in the docstring. Specifically, it closes the #31 .

# Changes:

- *-5*: open water is added to the necessary places in the documentation. 

# Questions to reviewer

However, it is not clear to me why: if landuse is raster, the raster can contain the following;
```
  - *nodata*: nodata
  - *-5*: open water
  - *-4*: grass
  - *-3*: forest
  - *-2*: infrastructure
  - *10*: agricultural fields
```

Yet, when the land use is vector, it should contain;
```
  - *-5*: open water
  - *-4*: grass land
  - *-3*: forest
  - *-2*: infrastructure (farms)
  - *-9999*: agricultural land
```

Moreover, under the land use setter, landuse raster is checked with the following set of expected values (nodata, -6, -5, -4, -3, -2, 10);
https://github.com/watem-sedem/pywatemsedem/blob/90893bfd2aba0fbedbe442e8eb8c9aca3d47a590/src/pywatemsedem/catchment.py#L447-L460
- if -6 grass strips is allowed, shall we add that to the docstring?
