### PR TITLE
use list instead of set

### DIFF
--- a/src/pywatemsedem/scenario.py
+++ b/src/pywatemsedem/scenario.py
@@ -432,8 +432,8 @@ class Scenario:
             self._vct_parcels.geodata,
             "Parcels",
             "LANDUSE",
-            {-9999, -2, -3, -4, -5},
-            classes={"agriculture", "infrastructure", "forest", "grass land", "water"},
+            [-9999, -2, -3, -4, -5],
+            classes=["agriculture", "infrastructure", "forest", "grass land", "water"],
         )
 
         if "NR" not in self._vct_parcels.geodata.columns:


### PR DESCRIPTION
This resolves the confusing error generated by vsct_parcels setters. Resultant text generated by the error function not correctly paired.

Specifically, it closes #30.

# Changes
Sets in Python are unordered collections, so when `zip` is used to combine `allowed_values` and `classes`, the order is not guaranteed to match the intended pairs. Thus, making use of lists for the `allowed_values` and `classes` (which is ordered by definition) should resolve the issue

