### PR TITLE
fix modelinput functions

### DIFF
--- a/src/pywatemsedem/io/modelinput.py
+++ b/src/pywatemsedem/io/modelinput.py
@@ -158,7 +158,7 @@ class Modelinput(Factory):
         valid_non_nan(self.buffers.arr)
         valid_array_type(self.buffers.arr, required_type=np.int16)
         valid_boundaries(self.buffers.arr, lower=0, upper=None)
-        valid_raster_properties_raster_with_template(self.rp, raster, epsg=self.rp.epsg)
+        check_raster_properties_raster_with_template(self.rp, raster, epsg=self.rp.epsg)
 
         labels = ["No buffer", "Buffer"]
 
@@ -215,7 +215,7 @@ class Modelinput(Factory):
         valid_nodata(self.dtm.arr, nodata_value=-99999)
         valid_boundaries(self.dtm.arr, lower=-431, upper=9000)
         # +- lowest and highest points on earth
-        valid_raster_properties_raster_with_template(self.rp, raster, epsg=self.rp.epsg)
+        check_raster_properties_raster_with_template(self.rp, raster, epsg=self.rp.epsg)
 
         def plot(fig=None, ax=None, *args, **kwargs):
             """Plot for DTM with cividis as colormap
@@ -266,7 +266,7 @@ class Modelinput(Factory):
         valid_boundaries(
             raster.arr[raster.arr != -9999], lower=0, upper=None
         )  # No data value excluded from check
-        valid_raster_properties_raster_with_template(
+        check_raster_properties_raster_with_template(
             self.rp, raster_input, epsg=self.rp.epsg
         )
         self._kfactor = raster
@@ -321,7 +321,7 @@ class Modelinput(Factory):
             self.ktc.arr[self.ktc.arr != 9999], lower=0, upper=20
         )  # 0 to 20 if not nodata
         valid_values(self.ktc.arr[self._ktc.arr > 20], [9999])
-        valid_raster_properties_raster_with_template(self.rp, raster, epsg=self.rp.epsg)
+        check_raster_properties_raster_with_template(self.rp, raster, epsg=self.rp.epsg)
 
         label = ["9999"]
 
@@ -378,7 +378,7 @@ class Modelinput(Factory):
         valid_nodata(self.outlet.arr)
         valid_array_type(self.outlet.arr, required_type=np.int16)
         valid_values(self.outlet.arr, unique_values=[0, 1])
-        valid_raster_properties_raster_with_template(self.rp, raster, epsg=self.rp.epsg)
+        check_raster_properties_raster_with_template(self.rp, raster, epsg=self.rp.epsg)
 
     @property
     def pfactor(self):
@@ -403,7 +403,7 @@ class Modelinput(Factory):
         lower, upper = 0, 1
         valid_boundaries(self.pfactor.arr, lower=lower, upper=upper)
         valid_array_type(self.pfactor.arr, required_type=np.float32)
-        valid_raster_properties_raster_with_template(self.rp, raster, epsg=self.rp.epsg)
+        check_raster_properties_raster_with_template(self.rp, raster, epsg=self.rp.epsg)
 
         def plot(fig=None, ax=None, *args, **kwargs):
             """Plot for P-factor
@@ -453,7 +453,7 @@ class Modelinput(Factory):
         valid_non_nan(self.compositelanduse.arr)
         valid_array_type(self.compositelanduse.arr, required_type=np.int16)
         valid_boundaries(self.compositelanduse.arr, lower=-32757, upper=32757)
-        valid_raster_properties_raster_with_template(self.rp, raster, epsg=self.rp.epsg)
+        check_raster_properties_raster_with_template(self.rp, raster, epsg=self.rp.epsg)
 
         # custom plotting features
         colormap = colors.ListedColormap(
@@ -529,7 +529,7 @@ class Modelinput(Factory):
         # int16, maar waarom niet float32?
         lower, upper = 0, 100
         valid_boundaries(self.ptef.arr, lower=lower, upper=upper)
-        valid_raster_properties_raster_with_template(self.rp, raster, epsg=self.rp.epsg)
+        check_raster_properties_raster_with_template(self.rp, raster, epsg=self.rp.epsg)
 
         def plot(fig=None, ax=None, *args, **kwargs):
             """Plot for PTEF
@@ -580,7 +580,7 @@ class Modelinput(Factory):
         valid_non_nan(self.ptef.arr)
         valid_array_type(self.ptef.arr, required_type=np.int16)
         valid_boundaries(self.ptef.arr, lower=0, upper=None)
-        valid_raster_properties_raster_with_template(self.rp, raster, epsg=self.rp.epsg)
+        check_raster_properties_raster_with_template(self.rp, raster, epsg=self.rp.epsg)
 
         def plot(fig=None, ax=None, *args, **kwargs):
             """Plot for riversegments
@@ -645,7 +645,7 @@ class Modelinput(Factory):
             self.riverrouting.arr[self.riverrouting.arr != -9999],
             unique_values=np.arange(0, 9).tolist(),
         )
-        valid_raster_properties_raster_with_template(self.rp, raster, epsg=self.rp.epsg)
+        check_raster_properties_raster_with_template(self.rp, raster, epsg=self.rp.epsg)
         colormap_start = mpl.cm.get_cmap("tab10")
         colorlist = []
         for i in range(0, 9):
@@ -715,7 +715,7 @@ class Modelinput(Factory):
         valid_array_type(self.sewers.arr, required_type=np.float32)
         lower, upper = 0, 1
         valid_boundaries(self.sewers.arr, lower=lower, upper=upper)
-        valid_raster_properties_raster_with_template(self.rp, raster, epsg=self.rp.epsg)
+        check_raster_properties_raster_with_template(self.rp, raster, epsg=self.rp.epsg)
 
         def plot(fig=None, ax=None, *args, **kwargs):
             """Plot for sewers

--- a/tests/io/test_modelinput.py
+++ b/tests/io/test_modelinput.py
@@ -2,17 +2,11 @@
 
 from pathlib import Path
 
-import pytest
-
 from pywatemsedem.io.modelinput import Modelinput
 
 # testing normal functioning
 
 
-@pytest.mark.skip(
-    reason="test gives saga-issues in conda pipeline, ommited, raised as"
-    " issue in saga"
-)
 def test_modelinput_all():
     """tests for Modelinput class"""
     # folder = Path(r"pywatemsedem/tests/io/data")

--- a/tests/io/test_modelinput.py
+++ b/tests/io/test_modelinput.py
@@ -1,11 +1,17 @@
 # implicit testing of the modelinput class
 from pathlib import Path
 
+import pytest
+
 from pywatemsedem.io.modelinput import Modelinput
 
 # testing normal functioning
 
 
+@pytest.mark.skip(
+    reason="test gives saga-issues in conda pipeline, ommited, raised as"
+    " issue in saga"
+)
 def test_modelinput_all():
     """tests for Modelinput class"""
     # folder = Path(r"pywatemsedem/tests/io/data")

--- a/tests/io/test_modelinput.py
+++ b/tests/io/test_modelinput.py
@@ -1,5 +1,4 @@
 # implicit testing of the modelinput class
-
 from pathlib import Path
 
 from pywatemsedem.io.modelinput import Modelinput


### PR DESCRIPTION
There were some references to a function name `valid_raster_properties_raster_with_template` whereas it should have been `check_raster_properties_raster_with_template`.