### PR TITLE
do not check for older version as it is not supported anymore

### DIFF
--- a/src/pywatemsedem/__init__.py
+++ b/src/pywatemsedem/__init__.py
@@ -1,12 +1,4 @@
-import sys
-
-if sys.version_info[:2] >= (3, 8):
-    # TODO: Import directly (no need for conditional) when `python_requires = >= 3.8`
-    from importlib.metadata import PackageNotFoundError  # pragma: no cover
-    from importlib.metadata import version
-else:
-    from importlib_metadata import PackageNotFoundError  # pragma: no cover
-    from importlib_metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
 try:
     # Change here if project is renamed and does not equal the package name


### PR DESCRIPTION
This PR closes #43. As the older version of python are not supported anymore by the package, it is not required to have if else statement in the init file.

Quotation from the discussion:
https://github.com/watem-sedem/pywatemsedem/issues/43#issuecomment-2740337940