### PR TITLE
Fix parcel_id overflow logic

### DIFF
--- a/src/pywatemsedem/scenario.py
+++ b/src/pywatemsedem/scenario.py
@@ -462,7 +462,7 @@ class Scenario:
             warnings.warn(msg)
             self._vct_parcels.geodata["NR"] = np.where(
                 self._vct_parcels.geodata["NR"] > 32767,
-                32767,
+                self._vct_parcels.geodata["NR"] % 2**15,
                 self._vct_parcels.geodata["NR"],
             )
 
@@ -504,7 +504,7 @@ class Scenario:
                 )
                 warnings.warn(msg)
 
-            arr = np.where(arr > 0, arr % 2**15, arr)
+                arr = np.where(arr > 32767, arr % (2**15), arr)
             arr = arr.astype(np.int16)
 
             return self.raster_factory(arr, allow_nodata_array=True)

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -389,8 +389,10 @@ class TestParcels(ScenarioTestBase):
         df["NR"] = 1000**2
 
         self.scenario.vct_parcels = df
+        # max id should be max(int16)
         assert np.max(self.scenario.parcels.arr) < 2**15
-        assert np.max(self.scenario.parcels_ids.arr) == 1000**2
+        # any higher id should have been reduced to fit
+        assert np.max(self.scenario.parcels_ids.arr) == (1000**2) % (2**15)
 
         # catch warning
         w = recwarn.pop(UserWarning)


### PR DESCRIPTION
If parcel ids overflow their int16 value, they should start again from 0, rather than all get the same value, because in that case changes are much higher that two neighbourin gparcels get the same code (and are considered the same parcel).